### PR TITLE
Add ruff CI for linting py code

### DIFF
--- a/.github/workflows/firmware-ci.yml
+++ b/.github/workflows/firmware-ci.yml
@@ -1,0 +1,16 @@
+name: 'Firmware CI'
+on: [pull_request]
+
+jobs:
+  firmware-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Lint Python with ruff
+        run: |
+          pip install ruff
+          cd firmware
+          ruff check .

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -8,6 +8,7 @@ import uasyncio as asyncio
 import usocket
 from clock import Clock
 from galactic import GalacticUnicorn
+from micropython import const
 from mqtt_as import MQTTClient, config as MQTT_BASE_CONFIG
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff.per-file-ignores]
+"mqtt_as.py" = ["E402", "E501"]


### PR DESCRIPTION
Includes ruff config to ignore errors from the mqtt_as.py as its a dependency.